### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-RadioshackStrip                KEYWORD1
+RadioshackStrip	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin                          KEYWORD2
-show                           KEYWORD2
-setPixelColor                  KEYWORD2
-setBrightness                  KEYWORD2
-numPixels                      KEYWORD2
-Color                          KEYWORD2
-getPixelColor                  KEYWORD2
+begin	KEYWORD2
+show	KEYWORD2
+setPixelColor	KEYWORD2
+setBrightness	KEYWORD2
+numPixels	KEYWORD2
+Color	KEYWORD2
+getPixelColor	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords